### PR TITLE
Stop specifying MY_EVN var

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,0 +1,7 @@
+{{- $choices := list "PERSONAL" "WORK" -}}
+{{- $myEnv := "CI" -}}
+{{- if stdinIsATTY -}}
+{{- $myEnv = promptChoiceOnce . "my_env" "Select the environment for this machine" $choices -}}
+{{- end -}}
+[data]
+    my_env = {{ $myEnv | quote }}

--- a/.chezmoiscripts/run_once_after_01-chores.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_01-chores.sh.tmpl
@@ -12,14 +12,14 @@ mkdir -p ${XDG_DATA_HOME}/fonts/{Meslo,Noto}
 fc-cache -v
 
 # Run xremap automatically
-if [ "$MY_ENV" != CI ]; then
+if [ "{{ .my_env }}" != CI ]; then
 	sudo cp ${XDG_CONFIG_HOME}/xremap/xremap.service /etc/systemd/system/
 	xhost +SI:localuser:root
 	sudo systemctl daemon-reload
 	sudo systemctl start xremap.service
 fi
 
-if [ "$MY_ENV" = PERSONAL ]; then
+if [ "{{ .my_env }}" = PERSONAL ]; then
 	sudo systemctl start docker
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  MY_ENV: CI
-
 jobs:
   test-macos:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test-macos:
     strategy:
       matrix:
-        os: [macos-14, macos-15, macos-26]
+        os: [macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup chezmoi

--- a/README.org
+++ b/README.org
@@ -6,6 +6,7 @@
 ** Usage
 - ~sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply granddaifuku~
 - On first run, chezmoi will ask which machine environment this is and store the answer for future applies.
+- You can inspect the stored environment with ~chezmoi cat-config~.
 - Non-interactive runs automatically use `CI`.
 
 ** Managed files

--- a/README.org
+++ b/README.org
@@ -4,8 +4,9 @@
 - [[https://github.com/twpayne/chezmoi][chezmoi]]
 
 ** Usage
-- ~MY_ENV=xxx sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply granddaifuku~
-MY_ENV could be one of `CI, PERSONAL, WORK`  
+- ~sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply granddaifuku~
+- On first run, chezmoi will ask which machine environment this is and store the answer for future applies.
+- Non-interactive runs automatically use `CI`.
 
 ** Managed files
 
@@ -22,4 +23,3 @@ MY_ENV could be one of `CI, PERSONAL, WORK`
 
 *** Linux
 - ~xremap~
-


### PR DESCRIPTION
## Changes
- Specify the environment (PERSONAL/WORK) when first running chezmoi.
- The environment config will be stored at `~/.config/chezmoi/chezmoi.toml`; you can see it by `chezmoi cat-config`

## Nit
- Stop supporting macos-14 (Sonoma)